### PR TITLE
csv import : spliting the csv line didn't include empty notes

### DIFF
--- a/src/com/github/wdkapps/fillup/GasRecord.java
+++ b/src/com/github/wdkapps/fillup/GasRecord.java
@@ -170,7 +170,7 @@ public class GasRecord implements Serializable {
 	 */
 	public GasRecord(String csv) throws ParseException, NumberFormatException {
 		this();
-		String[] values = csv.split(",");
+		String[] values = csv.split(",", -1);
 
 		switch(values.length){
 		case 8:  // db_version=5 with calculation


### PR DESCRIPTION
when importing a csv, spliting lines didn't include/consider empty notes on the list and so it loaded the line using the pre v5 model for v5 data bases export

solves #42 